### PR TITLE
Improve comatability between GLSL shader code and C++ includes

### DIFF
--- a/Shadinclude.hpp
+++ b/Shadinclude.hpp
@@ -89,6 +89,13 @@ public:
 				// Remove the include identifier, this will cause the path to remain
 				lineBuffer.erase(0, includeIndentifier.size());
 
+				// Remove quotation marks from the include-string, in case there are any
+				auto lineBufferQuotationMarkPositions = std::remove(lineBuffer.begin(), lineBuffer.end(), '\"');
+				while(lineBuffer.cend() != lineBufferQuotationMarkPositions) {
+					lineBuffer.erase(lineBufferQuotationMarkPositions, lineBuffer.cend());
+					lineBufferQuotationMarkPositions = std::remove(lineBuffer.begin(), lineBuffer.end(), '\"');
+				}
+
 				// The include path is relative to the current shader file path
 				std::string pathOfThisFile;
 				getFilePath(path, pathOfThisFile);


### PR DESCRIPTION
With this pull request I include the functionality to remove quotation marks from lines containing the includeIdentifier. This is mainly useful in scenarios in which GLSL files shoulds be included by both other GLSL files **and** C++ files.